### PR TITLE
Bump to version 2.2, allow override

### DIFF
--- a/lib/shareasale.js
+++ b/lib/shareasale.js
@@ -6,8 +6,8 @@ Affiliate = function($details) {
 	this.details = $details
 }
 Affiliate.prototype.Report = function($params, cb ) {
-    	$params.token = this.details.token
-	$params.version = '2.1'
+	$params.token = this.details.token
+	$params.version = typeof $params.version === 'undefined' ? '2.2' : $params.version
 	$params.XMLFormat = 1
 	$params.affiliateId = typeof $params.affiliateId === 'undefined' ? this.details.affiliateId : $params.affiliateId
 


### PR DESCRIPTION
Adds suggestion from #1: making `version` a parameter that can be overridden. Also bumped it to make 2.2 the default version.